### PR TITLE
Cursor fix

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -37,16 +37,16 @@
 //TODO: [design] introduce spikes earlier x
 //TODO: [design] subtract density from level 4, make it easier, make level 6 easier (less density, separate banana from coconut) x
 //TODO: [design] review score numbers and multiplers (should it be x10 or x100, how big does score get until end?)]
+//DONE: [bug] Fix HideCursor bug - Raylib ticket - https://github.com/raysan5/raylib/issues/4940
 
 //NEXT: add effect for filling jam to the top 
 //NEXT: Add bg elements to show max vertical movement (i.e. a vineyard with wooden frames, and one of the wood planks extends horizontally where max Y is)
 //--dev complete--
 
+//WIP: fix bugs
+//WIP: [bug] orange shows up in level 4???
+//WIP: [bug] EM build does not load levels correctly
 //TODO: add emscripten functions to handle quitting game so it doesn't freeze when hitting quit (or handle quit for web)
-//TODO: fix bugs
-//TODO: [bug] orange shows up in level 4???
-//NEXT: [bug] EM build does not load levels correctly
-//NEXT: [bug] Fix HideCursor bug
 //TODO: Update Readme
 //TODO: Look into adding this to itch.io
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -42,6 +42,7 @@
 //NEXT: Add bg elements to show max vertical movement (i.e. a vineyard with wooden frames, and one of the wood planks extends horizontally where max Y is)
 //--dev complete--
 
+//TODO: add emscripten functions to handle quitting game so it doesn't freeze when hitting quit (or handle quit for web)
 //TODO: fix bugs
 //TODO: [bug] orange shows up in level 4???
 //NEXT: [bug] EM build does not load levels correctly

--- a/game/include/display.hpp
+++ b/game/include/display.hpp
@@ -98,12 +98,12 @@ class Display {
         void Unload();
         const bool isStartButtonClicked() const;
         const bool isQuitButtonClicked() const;
-        void UpdateStartMenu(Vector2 mousePosition);
-        void RenderStartMenu() const;
+        void UpdateMenu(Vector2 mousePosition);
         void Update(const DisplayStats stats, const FruitDisplayResults results);
         void Render() const;
         void RenderReady() const;
         void UpdateOnce(int score, float timeEnd, float timeStart);
-        void RenderGameOver() const;
-        void RenderWin() const;
+        void RenderStartMenu() const;
+        void RenderOverMenu() const;
+        void RenderWinMenu() const;
 };

--- a/game/include/game.hpp
+++ b/game/include/game.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#include <html5.h>
+#include <functional>
+#endif
+
 #include "bucket.hpp"
 #include "display.hpp"
 #include "level.hpp"
@@ -57,6 +63,7 @@ class Game {
         const bool isRunning() const;
         const bool isDebug() const;
         void Loop();
+        void Pause();
         void Update();
         void UpdateDebug();
         void Render() const;

--- a/game/include/game.hpp
+++ b/game/include/game.hpp
@@ -2,8 +2,6 @@
 
 #ifdef __EMSCRIPTEN__
 #include <emscripten.h>
-#include <html5.h>
-#include <functional>
 #endif
 
 #include "bucket.hpp"
@@ -63,7 +61,7 @@ class Game {
         const bool isRunning() const;
         const bool isDebug() const;
         void Loop();
-        void Pause();
+        void LoopDebug();
         void Update();
         void UpdateDebug();
         void Render() const;

--- a/game/src/display.cpp
+++ b/game/src/display.cpp
@@ -177,7 +177,7 @@ const bool Display::isQuitButtonClicked(void) const {
     return quitButtonState == CLICKED;
 }
 
-void Display::UpdateStartMenu(Vector2 mousePosition) {
+void Display::UpdateMenu(Vector2 mousePosition) {
     if (CheckCollisionPointRec(mousePosition, startButtonCollision)) {
         startButtonState = HOVER;
         if(IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
@@ -271,7 +271,7 @@ void Display::UpdateOnce(int score, float timeEnd, float timeStart) {
     hudScoreFrameIdx = 0;
 }
 
-void Display::RenderGameOver() const {
+void Display::RenderOverMenu() const {
     const TextureParams& panel = panelTextureParams.at("gameOverPanel");
     DrawTexture(panel.texture, panel.x, panel.y, panel.color);
 
@@ -286,7 +286,7 @@ void Display::RenderGameOver() const {
     }
 }
 
-void Display::RenderWin() const {
+void Display::RenderWinMenu() const {
     for(const auto& textParams : gameEndTextParams) {
         const TextParams& entry = textParams.second;
         DrawTextEx(subFont, entry.text, { (float)entry.x, (float)entry.y }, entry.fontSize, 1.0f, entry.color);

--- a/game/src/main.cpp
+++ b/game/src/main.cpp
@@ -1,6 +1,3 @@
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
 #include "game.hpp"
 
 #define GAME_CONFIG_URI "game/jamslam.ini"
@@ -10,6 +7,20 @@ Game JamSlam(GAME_CONFIG_URI);
 void main_loop() {
   JamSlam.Loop();
 }
+
+#ifdef __EMSCRIPTEN__
+EMSCRIPTEN_KEEPALIVE
+EM_BOOL key_callback(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData) {
+    if (eventType == EMSCRIPTEN_EVENT_KEYDOWN) {
+        if (keyEvent->keyCode == 27) { // Escape key
+            JamSlam.Pause();
+            return true; // Consume the event
+         }
+         return true;
+    }
+    return false; // Don't consume the event
+}
+#endif
 
 int main() {
 
@@ -23,6 +34,7 @@ int main() {
   JamSlam.Load();
 
   #ifdef __EMSCRIPTEN__
+    emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, true, key_callback);
     emscripten_set_main_loop(main_loop, 0, 1);
   #else
     if(JamSlam.isDebug()){

--- a/game/src/main.cpp
+++ b/game/src/main.cpp
@@ -8,20 +8,6 @@ void main_loop() {
   JamSlam.Loop();
 }
 
-#ifdef __EMSCRIPTEN__
-EMSCRIPTEN_KEEPALIVE
-EM_BOOL key_callback(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData) {
-    if (eventType == EMSCRIPTEN_EVENT_KEYDOWN) {
-        if (keyEvent->keyCode == 27) { // Escape key
-            JamSlam.Pause();
-            return true; // Consume the event
-         }
-         return true;
-    }
-    return false; // Don't consume the event
-}
-#endif
-
 int main() {
 
   SetConfigFlags(FLAG_VSYNC_HINT);
@@ -29,25 +15,20 @@ int main() {
   
   InitWindow(SCREEN_WIDTH, SCREEN_HEIGHT, TEXT_GAME_TITLE);
   InitAudioDevice();
-  SetExitKey(KEY_NULL);
-  
   JamSlam.Load();
 
   #ifdef __EMSCRIPTEN__
-    emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, NULL, true, key_callback);
     emscripten_set_main_loop(main_loop, 0, 1);
   #else
+    SetTargetFPS(120);
+    
     if(JamSlam.isDebug()){
       while (!WindowShouldClose() && JamSlam.isRunning()) {
-        JamSlam.UpdateDebug();
-        BeginDrawing();
-        JamSlam.RenderDebug();
-        EndDrawing();
+        JamSlam.LoopDebug();
       }
     } else {
-      SetTargetFPS(120);
       while (!WindowShouldClose() && JamSlam.isRunning()) {
-          JamSlam.Loop();
+        JamSlam.Loop();
       }
     }
   #endif


### PR DESCRIPTION
- Changing Hide/ShowCursor to Enable/DisableCursor because Raylib is locking mouse position with hide/show
- Updating how mouse position is updated, using GetMouseDelta when cursor is disabled (as expected, but this breaks ESC pause)
- Changing pause key to P because browsers use ESC to exit locked mouse, and Hide/ShowCursor (which uses CSS pointer set to none for PLATFORM_WEB) is not working properly in Raylib
- Other minor changes and refactoring